### PR TITLE
Retry another available if one redis server is down

### DIFF
--- a/connection/hash_ring.go
+++ b/connection/hash_ring.go
@@ -124,7 +124,7 @@ func (myHashRing *HashRing) GetConnectionPool(command protocol.Command) (connect
 	for retry < myHashRing.BitMask && !connectionPool.IsConnected() {
 		hash = myHashRing.BitMask & (hash + 1)
 		connectionPool = myHashRing.ConnectionPools[hash]
-		retry += 1
+		retry++
 	}
 
 	for myHashRing.Failover && !connectionPool.IsConnected() {

--- a/connection/hash_ring.go
+++ b/connection/hash_ring.go
@@ -124,6 +124,7 @@ func (myHashRing *HashRing) GetConnectionPool(command protocol.Command) (connect
 	for retry < myHashRing.BitMask && !connectionPool.IsConnected() {
 		hash = myHashRing.BitMask & (hash + 1)
 		connectionPool = myHashRing.ConnectionPools[hash]
+		retry += 1
 	}
 
 	for myHashRing.Failover && !connectionPool.IsConnected() {


### PR DESCRIPTION
**Background:**
Currently, if a redis server is down, this server is not removed from hash ring. In this case,redis operation fails. From log, you can see this kind of error message: 
`ERR New Client Read Error: Hash ring is down`

This patch is simply to find next available redis server if one is down. 