### PR TITLE
Clearer hash ring down message when whole connection pools are down

### DIFF
--- a/connection/hash_ring.go
+++ b/connection/hash_ring.go
@@ -27,7 +27,7 @@ package connection
 
 import (
 	"errors"
-//	. "github.com/SalesforceEng/rmux/log"
+	//	. "github.com/SalesforceEng/rmux/log"
 	"github.com/SalesforceEng/rmux/protocol"
 )
 
@@ -56,11 +56,11 @@ func NewHashRing(connectionPools []*ConnectionPool, failover bool) (newHashRing 
 	if err != nil {
 		return
 	}
-//	Debug("Making a hash ring for prime %v", prime)
+	//	Debug("Making a hash ring for prime %v", prime)
 	newHashRing.Failover = failover
 	newHashRing.setBitMask(prime)
 	newHashRing.ConnectionPools = make([]*ConnectionPool, newHashRing.BitMask+1)
-//	Debug("Made a set of connection pools of size %v", len(newHashRing.ConnectionPools))
+	//	Debug("Made a set of connection pools of size %v", len(newHashRing.ConnectionPools))
 
 	newHashRing.distributeConnectionPools(prime, connectionPools)
 	return
@@ -120,6 +120,7 @@ func (myHashRing *HashRing) GetConnectionPool(command protocol.Command) (connect
 	hash = myHashRing.BitMask & hash
 	targetHash := hash
 	connectionPool = myHashRing.ConnectionPools[hash]
+	cycled := false
 
 	for myHashRing.Failover && !connectionPool.IsConnected() {
 		if hash == myHashRing.BitMask {
@@ -130,6 +131,7 @@ func (myHashRing *HashRing) GetConnectionPool(command protocol.Command) (connect
 
 		// If we've cycled through everything, break out
 		if hash == targetHash {
+			cycled = true
 			break
 		}
 
@@ -137,7 +139,16 @@ func (myHashRing *HashRing) GetConnectionPool(command protocol.Command) (connect
 	}
 
 	if !connectionPool.IsConnected() {
-		return nil, ERR_HASHRING_DOWN
+		if cycled {
+			endpointList := ""
+			for _, connectionPool := range myHashRing.ConnectionPools {
+				endpointList += connectionPool.Endpoint + ";"
+			}
+			return nil, errors.New("Hash ring is down. All ConnectionPools are not available: " + endpointList)
+
+		} else {
+			return nil, ERR_HASHRING_DOWN
+		}
 	} else {
 		return connectionPool, nil
 	}


### PR DESCRIPTION
When the error message of "Hash ring is down" comes, we don't know whether it is part outage or whole connection pools are down. This MR is used to show different messages for these two cases.