### PR TITLE
Fix DEL command with multiple keys

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -136,7 +136,7 @@ func IsSupportedFunction(command []byte, isMultiplexing, isMultipleArgument bool
 	if command[0] == 'd' {
 		//*del is only supported if we're not multiplexing, or there's only one argument
 		if command[2] == 'l' && isMultipleArgument {
-			return false
+			return !isMultiplexing
 		}
 		//supported: decr, decrby, del, dump
 		//unsupported: debug, dbsize, discard


### PR DESCRIPTION
Actually enable the `DEL` redis command when multiple keys are specified and multiplexing is disabled. According to a documentation string above the check this should work but seems to not have been implemented accordingly. This PR implements the check accordingly.