### PR TITLE
Implement basic Redis transaction support without multiplexing

### DIFF
--- a/DISABLED_COMMANDS.md
+++ b/DISABLED_COMMANDS.md
@@ -2,10 +2,6 @@
 
 The following redis commands are disabled, because they should generally be run on the actual redis server that you want information from:
 ```
-multi
-watch
-exec
-unwatch
 bgrewriteaof
 bgsave
 client
@@ -32,12 +28,14 @@ The following redis commands are disabled if multiplexing is enabled, because th
 ```
 discard
 eval
+exec
 bitop
 brpoplpush
 keys
 mget
 mset
 msetnx
+multi
 rename
 renamenx
 rpoplpush
@@ -49,6 +47,8 @@ sinter
 smove
 sunion
 sunionstore
+unwatch
+watch
 zinterstore
 zunionstore
 ```

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REDISSERV=redis-server
 REDISCLI=redis-cli
 INTSOCK=/tmp/redis-test.sock
 VER=0.3.3.2
-BUILDFLAGS=-ldflags "-X github.com/salesforce/rmux.version=$(VER)"
+BUILDFLAGS=-ldflags "rmux.version=$(VER)"
 
 all: clean test build-dev build
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Usage of rmux:
   -host="localhost": The host to listen for incoming connections on
   -localReadTimeout=0: Timeout to set locally (read)
   -localTimeout=0: Timeout to set locally (read+write)
+  -localTransactionTimeout=0: Timeout to set locally (transaction)
   -localWriteTimeout=0: Timeout to set locally (write)
   -maxProcesses=0: The number of processes to use.  If this is not defined, go's default is used.
   -poolSize=50: The size of the connection pools to use

--- a/client.go
+++ b/client.go
@@ -54,21 +54,40 @@ type Client struct {
 	DatabaseId int
 	//Whether or not this client connection is active or not
 	//Upon QUIT command, this gets toggled off
-	Active      bool
-	ReadChannel chan readItem
-	HashRing    *connection.HashRing
-	queued      []protocol.Command
-	Scanner     *protocol.RespScanner
+	Active                 bool
+	ReadChannel            chan readItem
+	HashRing               *connection.HashRing
+	Scanner                *protocol.RespScanner
+	TransactionTimeout     time.Duration
+	queued                 []protocol.Command
+	reservedRedisConn      *connection.Connection
+	transactionMode        transactionMode
+	transactionDoneChannel chan interface{}
 }
 
+// Represents the connection transaction mode of this client / connection
+type transactionMode byte
+
 var (
-	ERR_QUIT            = errors.New("Client asked to quit")
-	ERR_CONNECTION_DOWN = errors.New(string(CONNECTION_DOWN_RESPONSE))
-	ERR_TIMEOUT         = errors.New("Proxy timeout")
+	ERR_QUIT                = errors.New("Client asked to quit")
+	ERR_CONNECTION_DOWN     = errors.New(string(CONNECTION_DOWN_RESPONSE))
+	ERR_TIMEOUT             = errors.New("Proxy timeout")
+	ERR_TRANSACTION_TIMEOUT = errors.New("Transaction timeout")
+)
+
+const (
+	//Default transaction timeout, for clients. Can be adjusted on individual clients after initialization
+	EXTERN_TRANSACTION_TIMEOUT = time.Millisecond * 500
+
+	transactionModeNone transactionMode = iota
+	transactionModePre
+	transactionModeMulti
 )
 
 // Initializes a new client, for the given established net connection, with the specified read/write timeouts
-func NewClient(connection net.Conn, readTimeout, writeTimeout time.Duration, isMuliplexing bool, hashRing *connection.HashRing) (newClient *Client) {
+func NewClient(connection net.Conn, isMuliplexing bool, hashRing *connection.HashRing,
+	transactionTimeout time.Duration) (newClient *Client) {
+
 	newClient = &Client{}
 	newClient.Connection = connection
 	newClient.Writer = writer.NewFlexibleWriter(connection)
@@ -79,6 +98,8 @@ func NewClient(connection net.Conn, readTimeout, writeTimeout time.Duration, isM
 	newClient.HashRing = hashRing
 	newClient.DatabaseId = 0
 	newClient.Scanner = protocol.NewRespScanner(connection)
+	newClient.TransactionTimeout = transactionTimeout
+	newClient.transactionMode = transactionModeNone
 	return
 }
 
@@ -127,9 +148,7 @@ func (this *Client) FlushLine(line []byte) (err error) {
 }
 
 // Performs the query against the redis server and responds to the connected client with the response from redis.
-func (this *Client) FlushRedisAndRespond() error {
-	var err error
-
+func (this *Client) FlushRedisAndRespond() (err error) {
 	if !this.HasQueued() {
 		return this.Writer.Flush()
 	}
@@ -145,23 +164,65 @@ func (this *Client) FlushRedisAndRespond() error {
 		if err != nil {
 			log.Error("Failed to retrieve a connection pool from the hashring")
 			this.ReadChannel <- readItem{nil, err}
-			return err
+			return
 		}
 	}
 
-	redisConn, err := connectionPool.GetConnection()
-	if err != nil {
-		log.Error("Failed to retrieve an active connection from the provided connection pool")
-		this.ReadChannel <- readItem{nil, ERR_CONNECTION_DOWN}
-		return ERR_CONNECTION_DOWN
+	var redisConn *connection.Connection
+
+	if this.reservedRedisConn != nil {
+		redisConn = this.reservedRedisConn
+	} else {
+		redisConn, err = connectionPool.GetConnection()
+		if err != nil {
+			log.Error("Failed to retrieve an active connection from the provided connection pool")
+			this.ReadChannel <- readItem{nil, ERR_CONNECTION_DOWN}
+			return ERR_CONNECTION_DOWN
+		}
 	}
-	defer connectionPool.RecycleRemoteConnection(redisConn)
+
+	defer func() {
+		if this.transactionMode == transactionModeNone {
+			// We are not in a transaction, so we can simply recycle it
+			connectionPool.RecycleRemoteConnection(redisConn)
+
+			if this.reservedRedisConn != nil {
+				this.reservedRedisConn = nil
+
+			}
+			if this.transactionDoneChannel != nil {
+				close(this.transactionDoneChannel)
+				this.transactionDoneChannel = nil
+			}
+		} else {
+			// We are currently in a transaction
+			if err != nil {
+				// Reset client and server connection as we can not recover from any error states
+				this.ReadChannel <- readItem{nil, err}
+				redisConn.Disconnect()
+				close(this.transactionDoneChannel)
+				connectionPool.RecycleRemoteConnection(redisConn)
+			} else if this.reservedRedisConn == nil {
+				this.reservedRedisConn = redisConn
+				this.transactionDoneChannel = make(chan interface{}, 1)
+				go func() {
+					select {
+					case <-this.transactionDoneChannel:
+					case <-time.After(this.TransactionTimeout):
+						this.ReadChannel <- readItem{nil, ERR_TRANSACTION_TIMEOUT}
+						redisConn.Disconnect()
+						connectionPool.RecycleRemoteConnection(redisConn)
+					}
+				}()
+			}
+		}
+	}()
 
 	if redisConn.DatabaseId != this.DatabaseId {
-		if err := redisConn.SelectDatabase(this.DatabaseId); err != nil {
+		if err = redisConn.SelectDatabase(this.DatabaseId); err != nil {
 			// Disconnect the current connection if selecting failed, will auto-reconnect this connection holder when queried later
 			redisConn.Disconnect()
-			return err
+			return
 		}
 	}
 
@@ -170,30 +231,31 @@ func (this *Client) FlushRedisAndRespond() error {
 	startWrite := time.Now()
 
 	for _, command := range this.queued {
-		_, err := redisConn.Writer.Write(command.GetBuffer())
+		this.checkTransactionMode(command)
+		_, err = redisConn.Writer.Write(command.GetBuffer())
 		if err != nil {
 			log.Error("Error when writing to server: %s. Disconnecting the connection.", err)
 			redisConn.Disconnect()
-			return err
+			return
 		}
 	}
 	this.resetQueued()
 	for redisConn.Writer.Buffered() > 0 {
-		err := redisConn.Writer.Flush()
+		err = redisConn.Writer.Flush()
 		if err != nil {
 			log.Error("Error when flushing to server: %s. Disconnecting the connection.", err)
 			redisConn.Disconnect()
-			return err
+			return
 		}
 	}
 
 	graphite.Timing("redis_write", time.Now().Sub(startWrite))
 
-	if err := protocol.CopyServerResponses(redisConn.Reader, this.Writer, numCommands); err != nil {
+	if err = protocol.CopyServerResponses(redisConn.Reader, this.Writer, numCommands); err != nil {
 		log.Error("Error when copying redis responses to client: %s. Disconnecting the connection.", err)
 		redisConn.Disconnect()
 		this.ReadChannel <- readItem{nil, err}
-		return err
+		return
 	}
 
 	this.Writer.Flush()
@@ -231,4 +293,34 @@ func (this *Client) HasQueued() bool {
 
 func (this *Client) Queue(command protocol.Command) {
 	this.queued = append(this.queued, command)
+}
+
+func (this *Client) checkTransactionMode(command protocol.Command) {
+	commandName := command.GetCommand()
+
+	switch this.transactionMode {
+	case transactionModeNone:
+		if bytes.Equal(commandName, protocol.WATCH_COMMAND) {
+			// Enter pre transaction mode when receiving WATCH as this already imposes state on the server connection
+			this.transactionMode = transactionModePre
+		} else if bytes.Equal(commandName, protocol.MULTI_COMMAND) {
+			// Enter actual transaction mode when receiving MULTI
+			this.transactionMode = transactionModeMulti
+		}
+
+	case transactionModePre:
+		if bytes.Equal(commandName, protocol.UNWATCH_COMMAND) {
+			// Exit pre transaction mode when receiving UNWATCH
+			this.transactionMode = transactionModeNone
+		} else if bytes.Equal(commandName, protocol.MULTI_COMMAND) {
+			// Enter actual transaction mode when receiving MULTI
+			this.transactionMode = transactionModeMulti
+		}
+
+	case transactionModeMulti:
+		if bytes.Equal(commandName, protocol.EXEC_COMMAND) || bytes.Equal(commandName, protocol.DISCARD_COMMAND) {
+			// Exit transaction mode when receiving EXEC or DISCARD
+			this.transactionMode = transactionModeNone
+		}
+	}
 }

--- a/client.go
+++ b/client.go
@@ -208,6 +208,7 @@ func (this *Client) FlushRedisAndRespond() (err error) {
 					select {
 					case <-this.transactionDoneChannel:
 					case <-time.After(this.TransactionTimeout):
+						log.Error("Transaction timed out. Disconnecting the connection.")
 						this.ReadChannel <- readItem{nil, ERR_TRANSACTION_TIMEOUT}
 						redisConn.Disconnect()
 					}

--- a/client_test.go
+++ b/client_test.go
@@ -60,7 +60,7 @@ func TestReadCommand(t *testing.T) {
 		t.Fatal("Could not dial in to our local rmux sock")
 	}
 	defer testConnection.Close()
-	client := NewClient(testConnection, 1*time.Millisecond, 1*time.Millisecond, true, nil)
+	client := NewClient(testConnection, true, nil, 1*time.Millisecond)
 
 	for _, data := range testData {
 		input := bytes.NewBuffer([]byte(data.input))
@@ -134,7 +134,7 @@ func TestParseCommand(test *testing.T) {
 	}
 	defer testConnection.Close()
 
-	client := NewClient(testConnection, 1*time.Millisecond, 1*time.Millisecond, true, nil)
+	client := NewClient(testConnection, true, nil, 1*time.Millisecond)
 
 	for _, testCase := range testCases {
 		w := new(bytes.Buffer)

--- a/client_test.go
+++ b/client_test.go
@@ -29,9 +29,9 @@ package rmux
 import (
 	"bufio"
 	"bytes"
-	"github.com/salesforce/rmux/protocol"
-	"github.com/salesforce/rmux/writer"
 	"net"
+	"rmux/protocol"
+	"rmux/writer"
 	"testing"
 	"time"
 )
@@ -64,7 +64,6 @@ func TestReadCommand(t *testing.T) {
 
 	for _, data := range testData {
 		input := bytes.NewBuffer([]byte(data.input))
-
 
 		client.Writer = writer.NewFlexibleWriter(new(bytes.Buffer))
 		client.Scanner = protocol.NewRespScanner(input)
@@ -165,4 +164,3 @@ func TestParseCommand(test *testing.T) {
 		}
 	}
 }
-

--- a/connection/connection_pool.go
+++ b/connection/connection_pool.go
@@ -26,12 +26,12 @@
 package connection
 
 import (
-	. "github.com/salesforce/rmux/log"
-	"time"
-	"sync/atomic"
-	"github.com/salesforce/rmux/graphite"
+	"rmux/graphite"
+	"rmux/log"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 const (
@@ -43,7 +43,7 @@ const (
 	EXTERN_WRITE_TIMEOUT = time.Millisecond * 500
 )
 
-//A pool of connections to a single outbound redis server
+// A pool of connections to a single outbound redis server
 type ConnectionPool struct {
 	//The protocol to use for our connections (unix/tcp/udp)
 	Protocol string
@@ -58,19 +58,19 @@ type ConnectionPool struct {
 	//channel of recycled connections, for re-use
 	connectionPool chan *Connection
 	// The connection used for diagnostics (like checking that the pool is up)
-	diagnosticConnection *Connection
+	diagnosticConnection     *Connection
 	diagnosticConnectionLock sync.Mutex
 	// Number of active connections
-	Count int32
+	Count         int32
 	connectedLock sync.RWMutex
 	// Whether or not the connction pool is up or down
 	isConnected bool
 }
 
-//Initialize a new connection pool, for the given protocol/endpoint, with a given pool capacity
-//ex: "unix", "/tmp/myAwesomeSocket", 5
+// Initialize a new connection pool, for the given protocol/endpoint, with a given pool capacity
+// ex: "unix", "/tmp/myAwesomeSocket", 5
 func NewConnectionPool(Protocol, Endpoint string, poolCapacity int, connectTimeout time.Duration,
-		readTimeout time.Duration, writeTimeout time.Duration) (newConnectionPool *ConnectionPool) {
+	readTimeout time.Duration, writeTimeout time.Duration) (newConnectionPool *ConnectionPool) {
 	newConnectionPool = &ConnectionPool{}
 	newConnectionPool.Protocol = Protocol
 	newConnectionPool.Endpoint = Endpoint
@@ -90,7 +90,7 @@ func NewConnectionPool(Protocol, Endpoint string, poolCapacity int, connectTimeo
 	return
 }
 
-//Gets a connection from the connection pool
+// Gets a connection from the connection pool
 func (cp *ConnectionPool) GetConnection() (connection *Connection, err error) {
 	select {
 	case connection = <-cp.connectionPool:
@@ -99,13 +99,13 @@ func (cp *ConnectionPool) GetConnection() (connection *Connection, err error) {
 		if err := connection.ReconnectIfNecessary(); err != nil {
 			// Recycle the holder, return an error
 			cp.RecycleRemoteConnection(connection)
-			Error("Received a nil connection in pool.GetConnection: %s", err)
-			graphite.Increment("reconnect_error");
+			log.Error("Received a nil connection in pool.GetConnection: %s", err)
+			graphite.Increment("reconnect_error")
 			return nil, err
 		}
 
 		return connection, nil
-	// TODO: Maybe a while/timeout/graphiteping loop?
+		// TODO: Maybe a while/timeout/graphiteping loop?
 	}
 }
 
@@ -124,7 +124,7 @@ func (cp *ConnectionPool) getDiagnosticConnection() (connection *Connection, err
 	cp.diagnosticConnectionLock.Lock()
 
 	if err := cp.diagnosticConnection.ReconnectIfNecessary(); err != nil {
-		Error("The diangnostic connection is down for %s:%s : %s", cp.Protocol, cp.Endpoint, err)
+		log.Error("The diangnostic connection is down for %s:%s : %s", cp.Protocol, cp.Endpoint, err)
 		cp.diagnosticConnectionLock.Unlock()
 		return nil, err
 	}
@@ -136,8 +136,8 @@ func (cp *ConnectionPool) releaseDiagnosticConnection() {
 	cp.diagnosticConnectionLock.Unlock()
 }
 
-//Recycles a connection back into our connection pool
-//If the pool is full, throws it away
+// Recycles a connection back into our connection pool
+// If the pool is full, throws it away
 func (myConnectionPool *ConnectionPool) RecycleRemoteConnection(remoteConnection *Connection) {
 	myConnectionPool.connectionPool <- remoteConnection
 	atomic.AddInt32(&myConnectionPool.Count, -1)
@@ -155,8 +155,8 @@ func (cp *ConnectionPool) IsConnected() bool {
 	return cp.isConnected
 }
 
-//Checks the state of connections in this connection pool
-//If a remote server has severe lag, mysteriously goes away, or stops responding all-together, returns false
+// Checks the state of connections in this connection pool
+// If a remote server has severe lag, mysteriously goes away, or stops responding all-together, returns false
 func (cp *ConnectionPool) CheckConnectionState() (isUp bool) {
 	isUp = true
 	defer func() {
@@ -171,7 +171,7 @@ func (cp *ConnectionPool) CheckConnectionState() (isUp bool) {
 	defer cp.releaseDiagnosticConnection()
 
 	//If we failed to bind, or if our PING fails, the pool is down
-	if connection == nil || connection.connection == nil  {
+	if connection == nil || connection.connection == nil {
 		isUp = false
 		return
 	}
@@ -189,5 +189,5 @@ func (cp *ConnectionPool) ReportGraphite() {
 	endpoint := strings.Replace(cp.Endpoint, ".", "-", -1)
 	endpoint = strings.Replace(cp.Endpoint, ":", "-", -1)
 
-	graphite.Gauge("pools." + endpoint, int(cp.Count))
+	graphite.Gauge("pools."+endpoint, int(cp.Count))
 }

--- a/connection/connection_pool_test.go
+++ b/connection/connection_pool_test.go
@@ -26,14 +26,14 @@
 package connection
 
 import (
+	"bytes"
 	"net"
+	"os"
+	"regexp"
+	"rmux/protocol"
+	"sync"
 	"testing"
 	"time"
-	"regexp"
-	"os"
-	"sync"
-	"github.com/salesforce/rmux/protocol"
-	"bytes"
 )
 
 func TestRecycleConnection(test *testing.T) {

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -29,8 +29,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/salesforce/rmux/writer"
 	"net"
+	"rmux/writer"
 	"testing"
 	"time"
 )

--- a/connection/doc.go
+++ b/connection/doc.go
@@ -23,7 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-//Package rmux/connection provides a way to open outbound connections to redis servers.
-//Connections are aware of redis databases and subscriptions, and come with a connectionPool for recycling.
+// Package rmux/connection provides a way to open outbound connections to redis servers.
+// Connections are aware of redis databases and subscriptions, and come with a connectionPool for recycling.
 package connection

--- a/connection/hash_ring.go
+++ b/connection/hash_ring.go
@@ -27,14 +27,13 @@ package connection
 
 import (
 	"errors"
-//	. "github.com/salesforce/rmux/log"
-	"github.com/salesforce/rmux/protocol"
+	"rmux/protocol"
 )
 
 var ERR_HASHRING_DOWN = errors.New("Hash ring is down")
 
-//An outbound connection to a redis server
-//Maintains its own underlying TimedNetReadWriter, and keeps track of its DatabaseId for select() changes
+// An outbound connection to a redis server
+// Maintains its own underlying TimedNetReadWriter, and keeps track of its DatabaseId for select() changes
 type HashRing struct {
 	//The connection pools that we will be hashing our connections to
 	ConnectionPools []*ConnectionPool
@@ -56,11 +55,11 @@ func NewHashRing(connectionPools []*ConnectionPool, failover bool) (newHashRing 
 	if err != nil {
 		return
 	}
-//	Debug("Making a hash ring for prime %v", prime)
+	//	Debug("Making a hash ring for prime %v", prime)
 	newHashRing.Failover = failover
 	newHashRing.setBitMask(prime)
 	newHashRing.ConnectionPools = make([]*ConnectionPool, newHashRing.BitMask+1)
-//	Debug("Made a set of connection pools of size %v", len(newHashRing.ConnectionPools))
+	//	Debug("Made a set of connection pools of size %v", len(newHashRing.ConnectionPools))
 
 	newHashRing.distributeConnectionPools(prime, connectionPools)
 	return
@@ -105,8 +104,8 @@ func (myHashRing *HashRing) setBitMask(prime int) {
 	myHashRing.BitMask = myHashRing.BitMask - 1
 }
 
-//Gets the connectionKey, for a to-be-multiplexed command
-//Uses the bernstein hash, which is one of the fastest key-distribution algorithms out there
+// Gets the connectionKey, for a to-be-multiplexed command
+// Uses the bernstein hash, which is one of the fastest key-distribution algorithms out there
 func (myHashRing *HashRing) GetConnectionPool(command protocol.Command) (connectionPool *ConnectionPool, err error) {
 	var hash uint32 = 0
 	if command.GetArgCount() > 0 {

--- a/doc.go
+++ b/doc.go
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-//Package rmux provides a connection-pooling, multiplexing redis server.
-//Commands are parsed, and multiplexed out based on their arguments.
-//Package rmux/main includes a working server implementation, if no customization is needed
+// Package rmux provides a connection-pooling, multiplexing redis server.
+// Commands are parsed, and multiplexed out based on their arguments.
+// Package rmux/main includes a working server implementation, if no customization is needed
 package rmux

--- a/doc/config.md
+++ b/doc/config.md
@@ -7,6 +7,7 @@ Configuration can be handled either via command-line arguments or via config fil
   -host="localhost": The host to listen for incoming connections on
   -localReadTimeout=0: Timeout to set locally (read)
   -localTimeout=0: Timeout to set locally (read+write)
+  -localTransactionTimeout=0: Timeout to set locally (transaction)
   -localWriteTimeout=0: Timeout to set locally (write)
   -maxProcesses=0: The number of processes to use.  If this is not defined, go's default is used.
   -poolSize=50: The size of the connection pools to use
@@ -38,6 +39,7 @@ for the configuration json is as follows:
     "localTimeout": int,
     "localReadTimeout": int,
     "localWriteTimeout": int,
+    "localTransactionTimeout": int,
 
     "remoteTimeout": int,
     "remoteReadTimeout": int,

--- a/func_client_test.go
+++ b/func_client_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 /*
  * Copyright (c) 2015, Salesforce.com, Inc.
@@ -28,15 +28,15 @@
 package rmux
 
 import (
+	"bytes"
+	"net"
+	"rmux/connection"
 	"testing"
 	"time"
-	"net"
-	"github.com/salesforce/rmux/connection"
-	"bytes"
 )
 
 func TestConnectTimeout(t *testing.T) {
-	timeouts := []time.Duration {
+	timeouts := []time.Duration{
 		10 * time.Millisecond,
 		20 * time.Millisecond,
 		30 * time.Millisecond,
@@ -49,7 +49,6 @@ func TestConnectTimeout(t *testing.T) {
 		return
 	}
 	defer rmux.Listener.Close()
-
 
 	for _, timeout := range timeouts {
 		rmux.EndpointConnectTimeout = timeout
@@ -69,9 +68,9 @@ func TestConnectTimeout(t *testing.T) {
 		}
 
 		diff := time.Now().Sub(start)
-		if diff < timeout || diff > timeout + (10 * time.Millisecond) {
+		if diff < timeout || diff > timeout+(10*time.Millisecond) {
 			t.Errorf("Should have timed out in the given interval between %s and %s, but instead timed out in %s",
-				timeout, timeout + 10 * time.Millisecond, diff)
+				timeout, timeout+10*time.Millisecond, diff)
 		}
 
 		// Clear the pool

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module rmux
+
+go 1.19

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -26,11 +26,11 @@
 package graphite
 
 import (
-	"os"
-	"net"
 	"fmt"
-	"strings"
+	"net"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -51,7 +51,7 @@ func SetEndpoint(endpoint string) error {
 	// replace any dots in the hostname with dashes
 	hostname = strings.Replace(hostname, ".", "-", -1)
 
-	conn, err := net.DialUDP("udp", nil, addr);
+	conn, err := net.DialUDP("udp", nil, addr)
 	if err != nil {
 		return err
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,4 +1,4 @@
-// +build integration
+//go:build integration
 
 /*
  * Copyright (c) 2015, Salesforce.com, Inc.
@@ -29,12 +29,12 @@ package rmux
 
 import (
 	"bytes"
+	"io"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
-	"strconv"
-	"io"
 )
 
 type tRmux struct {
@@ -239,10 +239,9 @@ func TestLargeResponseWithValidation(t *testing.T) {
 
 func TestLargeRequest(t *testing.T) {
 	// The data to set: 26 bytes * 3000 = 78000 bytes
-	setData := strings.Repeat("abcdefghijklmnopqrstuvwxyz", 3000);
+	setData := strings.Repeat("abcdefghijklmnopqrstuvwxyz", 3000)
 	cmd := makeCommand("set somekey " + setData)
 	expected := "+OK\r\n"
 
 	checkResponse(t, cmd, expected)
 }
-

--- a/log/log.go
+++ b/log/log.go
@@ -52,7 +52,7 @@ func SetLogLevel(level int) {
 	_level = level
 }
 
-func UseSyslog(useSyslog bool)  {
+func UseSyslog(useSyslog bool) {
 	_enableSyslog = useSyslog
 	if useSyslog {
 		var e error

--- a/log/log_dev.go
+++ b/log/log_dev.go
@@ -1,4 +1,4 @@
-// +build dev
+//go:build dev
 
 /*
  * Copyright (c) 2015, Salesforce.com, Inc.
@@ -24,7 +24,6 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 
 package log
 

--- a/log/log_prod.go
+++ b/log/log_prod.go
@@ -1,4 +1,4 @@
-// +build !dev
+//go:build !dev
 
 /*
  * Copyright (c) 2015, Salesforce.com, Inc.

--- a/main/config.go
+++ b/main/config.go
@@ -38,14 +38,14 @@ type PoolConfig struct {
 	PoolSize             int      `json:"poolSize"`
 	TcpConnections       []string `json:"tcpConnections"`
 	UnixConnections      []string `json:"unixConnections"`
-	LocalTimeout         int64      `json:"localTimeout"`
-	LocalReadTimeout     int64      `json:"localReadTimeout"`
-	LocalWriteTimeout    int64      `json:"localWriteTimeout"`
-	RemoteTimeout        int64      `json:"remoteTimeout"`
-	RemoteReadTimeout    int64      `json:"remoteReadTimeout"`
-	RemoteWriteTimeout   int64      `json:"remoteWriteTimeout"`
-	RemoteConnectTimeout int64      `json:"remoteConnectTimeout"`
-	Failover             bool       `json:"failover"`
+	LocalTimeout         int64    `json:"localTimeout"`
+	LocalReadTimeout     int64    `json:"localReadTimeout"`
+	LocalWriteTimeout    int64    `json:"localWriteTimeout"`
+	RemoteTimeout        int64    `json:"remoteTimeout"`
+	RemoteReadTimeout    int64    `json:"remoteReadTimeout"`
+	RemoteWriteTimeout   int64    `json:"remoteWriteTimeout"`
+	RemoteConnectTimeout int64    `json:"remoteConnectTimeout"`
+	Failover             bool     `json:"failover"`
 }
 
 func ReadConfigFromFile(configFile string) ([]PoolConfig, error) {

--- a/main/main.go
+++ b/main/main.go
@@ -55,6 +55,7 @@ var unixConnections = flag.String("unixConnections", "", "Unix connections (dest
 var localTimeout = flag.Int64("localTimeout", 0, "Timeout to set locally in milliseconds (read+write)")
 var localReadTimeout = flag.Int64("localReadTimeout", 0, "Timeout to set locally in milliseconds (read)")
 var localWriteTimeout = flag.Int64("localWriteTimeout", 0, "Timeout to set locally (write)")
+var localTransactionTimeout = flag.Int64("localTransactionTimeout", 0, "Timeout to set for locally in milliseconds (connect)")
 var remoteTimeout = flag.Int64("remoteTimeout", 0, "Timeout to set for remote redises (connect+read+write)")
 var remoteReadTimeout = flag.Int64("remoteReadTimeout", 0, "Timeout to set for remote redises (read)")
 var remoteWriteTimeout = flag.Int64("remoteWriteTimeout", 0, "Timeout to set for remote redises (write)")
@@ -142,9 +143,10 @@ func configureFromArgs() ([]PoolConfig, error) {
 		TcpConnections:  arrTcpConnections,
 		UnixConnections: arrUnixConnections,
 
-		LocalTimeout:      *localTimeout,
-		LocalReadTimeout:  *localReadTimeout,
-		LocalWriteTimeout: *localWriteTimeout,
+		LocalTimeout:            *localTimeout,
+		LocalReadTimeout:        *localReadTimeout,
+		LocalWriteTimeout:       *localWriteTimeout,
+		LocalTransactionTimeout: *localTransactionTimeout,
 
 		RemoteTimeout:        *remoteTimeout,
 		RemoteReadTimeout:    *remoteReadTimeout,
@@ -218,6 +220,12 @@ func createInstances(configs []PoolConfig) (rmuxInstances []*rmux.RedisMultiplex
 			timeout := time.Duration(config.LocalWriteTimeout) * time.Millisecond
 			rmuxInstance.ClientWriteTimeout = timeout
 			log.Info("Setting local client write timeout to: %s", timeout)
+		}
+
+		if config.LocalTransactionTimeout != 0 {
+			timeout := time.Duration(config.LocalTransactionTimeout) * time.Millisecond
+			rmuxInstance.ClientTransactionTimeout = timeout
+			log.Info("Setting local client transaction timeout to: %s", timeout)
 		}
 
 		if config.RemoteTimeout != 0 {

--- a/main/main.go
+++ b/main/main.go
@@ -29,17 +29,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/salesforce/rmux"
-	. "github.com/salesforce/rmux/log"
 	"net"
 	"os"
+	"rmux"
+	"rmux/graphite"
+	"rmux/log"
 	"runtime"
 	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync"
 	"syscall"
-	"github.com/salesforce/rmux/graphite"
 	"time"
 )
 
@@ -82,22 +82,22 @@ func main() {
 	}
 
 	if *doDebug {
-		SetLogLevel(LOG_DEBUG)
+		log.SetLogLevel(log.LOG_DEBUG)
 	} else {
-		SetLogLevel(LOG_INFO)
+		log.SetLogLevel(log.LOG_INFO)
 	}
-	UseSyslog(*useSyslog)
+	log.UseSyslog(*useSyslog)
 
 	if *graphiteServer != "" {
-		Info("Enabling graphite stats")
+		log.Info("Enabling graphite stats")
 		err := graphite.SetEndpoint(*graphiteServer)
 		if err != nil {
-			Error("Error when setting graphite endpoint: %s", err)
+			log.Error("Error when setting graphite endpoint: %s", err)
 		}
 	}
 
 	if *doTiming {
-		Info("Enabling graphite timings")
+		log.Info("Enabling graphite timings")
 		graphite.EnableTimings()
 	}
 
@@ -111,7 +111,7 @@ func main() {
 	rmuxInstances, err := createInstances(configs)
 	terminateIfError(err, "Error creating rmux instances: %s\r\n")
 
-	Info("Starting %d rmux instances", len(rmuxInstances))
+	log.Info("Starting %d rmux instances", len(rmuxInstances))
 
 	start(rmuxInstances)
 }
@@ -176,20 +176,20 @@ func createInstances(configs []PoolConfig) (rmuxInstances []*rmux.RedisMultiplex
 		var rmuxInstance *rmux.RedisMultiplexer
 
 		if config.MaxProcesses > 0 {
-			Info("Max processes increased to: %d from: %d", config.MaxProcesses, runtime.GOMAXPROCS(config.MaxProcesses))
+			log.Info("Max processes increased to: %d from: %d", config.MaxProcesses, runtime.GOMAXPROCS(config.MaxProcesses))
 		}
 
 		if config.PoolSize < 1 {
-			Info("Pool size must be positive - defaulting to %d", DEFAULT_POOL_SIZE)
+			log.Info("Pool size must be positive - defaulting to %d", DEFAULT_POOL_SIZE)
 			config.PoolSize = DEFAULT_POOL_SIZE
 		}
 
 		if config.Socket != "" {
 			syscall.Umask(0111)
-			Info("Initializing rmux server on socket %s", config.Socket)
+			log.Info("Initializing rmux server on socket %s", config.Socket)
 			rmuxInstance, err = rmux.NewRedisMultiplexer("unix", config.Socket, config.PoolSize)
 		} else {
-			Info("Initializing rmux server on host: %s and port: %d", config.Host, config.Port)
+			log.Info("Initializing rmux server on host: %s and port: %d", config.Host, config.Port)
 			rmuxInstance, err = rmux.NewRedisMultiplexer("tcp", net.JoinHostPort(config.Host, strconv.Itoa(config.Port)), config.PoolSize)
 		}
 
@@ -205,19 +205,19 @@ func createInstances(configs []PoolConfig) (rmuxInstances []*rmux.RedisMultiplex
 			timeout := time.Duration(config.LocalTimeout) * time.Millisecond
 			rmuxInstance.ClientReadTimeout = timeout
 			rmuxInstance.ClientWriteTimeout = timeout
-			Info("Setting local client read and write timeouts to: %s", timeout)
+			log.Info("Setting local client read and write timeouts to: %s", timeout)
 		}
 
 		if config.LocalReadTimeout != 0 {
 			timeout := time.Duration(config.LocalReadTimeout) * time.Millisecond
 			rmuxInstance.ClientReadTimeout = timeout
-			Info("Setting local client read timeout to: %s", timeout)
+			log.Info("Setting local client read timeout to: %s", timeout)
 		}
 
 		if config.LocalWriteTimeout != 0 {
 			timeout := time.Duration(config.LocalWriteTimeout) * time.Millisecond
 			rmuxInstance.ClientWriteTimeout = timeout
-			Info("Setting local client write timeout to: %s", timeout)
+			log.Info("Setting local client write timeout to: %s", timeout)
 		}
 
 		if config.RemoteTimeout != 0 {
@@ -225,37 +225,37 @@ func createInstances(configs []PoolConfig) (rmuxInstances []*rmux.RedisMultiplex
 			rmuxInstance.EndpointConnectTimeout = duration
 			rmuxInstance.EndpointReadTimeout = duration
 			rmuxInstance.EndpointWriteTimeout = duration
-			Info("Setting remote redis connect, read, and write timeouts to: %s", duration)
+			log.Info("Setting remote redis connect, read, and write timeouts to: %s", duration)
 		}
 
 		if config.RemoteConnectTimeout != 0 {
 			duration := time.Duration(config.RemoteConnectTimeout) * time.Millisecond
 			rmuxInstance.EndpointConnectTimeout = duration
-			Info("Setting remote redis connect timeout to: %s", duration)
+			log.Info("Setting remote redis connect timeout to: %s", duration)
 		}
 
 		if config.RemoteReadTimeout != 0 {
 			duration := time.Duration(config.RemoteReadTimeout) * time.Millisecond
 			rmuxInstance.EndpointReadTimeout = duration
-			Info("Setting remote redis read timeouts to: %s", duration)
+			log.Info("Setting remote redis read timeouts to: %s", duration)
 		}
 
 		if config.RemoteWriteTimeout != 0 {
 			duration := time.Duration(config.RemoteWriteTimeout) * time.Millisecond
 			rmuxInstance.EndpointWriteTimeout = duration
-			Info("Setting remote redis write timeout to: %s", duration)
+			log.Info("Setting remote redis write timeout to: %s", duration)
 		}
 
 		if len(config.TcpConnections) > 0 {
 			for _, tcpConnection := range config.TcpConnections {
-				Info("Adding tcp (destination) connection: %s", tcpConnection)
+				log.Info("Adding tcp (destination) connection: %s", tcpConnection)
 				rmuxInstance.AddConnection("tcp", tcpConnection)
 			}
 		}
 
 		if len(config.UnixConnections) > 0 {
 			for _, unixConnection := range config.UnixConnections {
-				Info("Adding unix (destination) connection: %s", unixConnection)
+				log.Info("Adding unix (destination) connection: %s", unixConnection)
 				rmuxInstance.AddConnection("unix", unixConnection)
 			}
 		}
@@ -301,7 +301,7 @@ func terminateIfError(err error, format string, a ...interface{}) {
 	if err != nil {
 		allArgs := append([]interface{}{err}, a...)
 
-		Error(format, allArgs...)
+		log.Error(format, allArgs...)
 		os.Exit(1)
 	}
 }

--- a/protocol/command.go
+++ b/protocol/command.go
@@ -25,7 +25,7 @@
 
 package protocol
 
-//Represents a redis client that is connected to our rmux server
+// Represents a redis client that is connected to our rmux server
 type Command interface {
 	GetCommand() []byte
 	GetBuffer() []byte

--- a/protocol/doc.go
+++ b/protocol/doc.go
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-//Package rmux/protocol provides a standard way to listen in on the redis protocol,
-//look ahead to what commands are about to be executed, and ignore them or pass them
-//on to another buffer, as desired
+// Package rmux/protocol provides a standard way to listen in on the redis protocol,
+// look ahead to what commands are about to be executed, and ignore them or pass them
+// on to another buffer, as desired
 package protocol

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -27,8 +27,8 @@ package protocol
 
 import (
 	"bufio"
-	. "github.com/salesforce/rmux/writer"
 	"io"
+	"rmux/writer"
 )
 
 const (
@@ -306,12 +306,12 @@ func IsSupportedFunction(command []byte, isMultiplexing, isMultipleArgument bool
 	return false
 }
 
-//Parses a string into an int.
-//Differs from atoi in that this only parses positive dec ints--hex, octal, and negatives are not allowed
-//Upon invalid character received, a PANIC_INVALID_INT is caught and err'd
+// Parses a string into an int.
+// Differs from atoi in that this only parses positive dec ints--hex, octal, and negatives are not allowed
+// Upon invalid character received, a PANIC_INVALID_INT is caught and err'd
 func ParseInt(response []byte) (value int, err error) {
 	if len(response) == 0 {
-//		Debug("ParseInt: Zero-length int")
+		//		Debug("ParseInt: Zero-length int")
 		err = ERROR_INVALID_INT
 		return
 	}
@@ -329,7 +329,7 @@ func ParseInt(response []byte) (value int, err error) {
 		b = b - '0'
 		//Since we know we have a positive value, we can now do this single check
 		if b > 9 {
-//			Debug("ParseInt: Invalid int character: %q when parsing %q", b+'0', response)
+			//			Debug("ParseInt: Invalid int character: %q when parsing %q", b+'0', response)
 			err = ERROR_INVALID_INT
 			return
 		}
@@ -370,18 +370,18 @@ func ParseCommand(b []byte) (command Command, err error) {
 	return
 }
 
-//Writes the given error to the buffer, preceded by a '-' and followed by a GO_NEWLINE
-//Bubbles any errors from underlying writer
-func WriteError(line []byte, dest *FlexibleWriter, flush bool) (err error) {
+// Writes the given error to the buffer, preceded by a '-' and followed by a GO_NEWLINE
+// Bubbles any errors from underlying writer
+func WriteError(line []byte, dest *writer.FlexibleWriter, flush bool) (err error) {
 	_, err = dest.Write([]byte("-ERR "))
 	if err != nil {
-//		Debug("WriteError: Error received from write: %s", err)
+		//		Debug("WriteError: Error received from write: %s", err)
 		return err
 	}
 
 	err = WriteLine(line, dest, flush)
 	if err != nil {
-//		Debug("WriteError: Error received from write: %s", err)
+		//		Debug("WriteError: Error received from write: %s", err)
 		return err
 	}
 
@@ -392,19 +392,19 @@ func WriteError(line []byte, dest *FlexibleWriter, flush bool) (err error) {
 	return
 }
 
-//Writes the given line to the buffer, followed by a GO_NEWLINE
-//Does not explicitly flush the buffer.  Final lines in a sequence should be followed by FlushLine
-func WriteLine(line []byte, destination *FlexibleWriter, flush bool) (err error) {
+// Writes the given line to the buffer, followed by a GO_NEWLINE
+// Does not explicitly flush the buffer.  Final lines in a sequence should be followed by FlushLine
+func WriteLine(line []byte, destination *writer.FlexibleWriter, flush bool) (err error) {
 	// startTime := time.Now()
 	_, err = destination.Write(line)
 	if err != nil {
-//		Debug("writeLine: Error received from write: %s", err)
+		//		Debug("writeLine: Error received from write: %s", err)
 		return
 	}
 
 	_, err = destination.Write(REDIS_NEWLINE)
 	if err != nil {
-//		Debug("writeLine: Error received from writing GO_NEWLINE: %s", err)
+		//		Debug("writeLine: Error received from writing GO_NEWLINE: %s", err)
 		return
 	}
 
@@ -415,9 +415,9 @@ func WriteLine(line []byte, destination *FlexibleWriter, flush bool) (err error)
 	return
 }
 
-//Copies a server response from the remoteBuffer into your localBuffer
-//If a protocol or buffer error is encountered, it is bubbled up
-func CopyServerResponses(reader *bufio.Reader, localBuffer *FlexibleWriter, numResponses int) (err error) {
+// Copies a server response from the remoteBuffer into your localBuffer
+// If a protocol or buffer error is encountered, it is bubbled up
+func CopyServerResponses(reader *bufio.Reader, localBuffer *writer.FlexibleWriter, numResponses int) (err error) {
 	//start := time.Now()
 	//defer func() {
 	//	graphite.Timing("copy_server_responses", time.Now().Sub(start))
@@ -427,7 +427,7 @@ func CopyServerResponses(reader *bufio.Reader, localBuffer *FlexibleWriter, numR
 
 	numRead := 0
 
-	for ; numRead < numResponses && scanner.Scan(); {
+	for numRead < numResponses && scanner.Scan() {
 		localBuffer.Write(scanner.Bytes())
 		localBuffer.Flush()
 		numRead++

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -28,7 +28,7 @@ package protocol
 import (
 	"bufio"
 	"bytes"
-	"github.com/salesforce/rmux/writer"
+	"rmux/writer"
 	"strings"
 	"testing"
 )

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -184,12 +184,12 @@ var testDataAllRedisCommands = []struct {
 	{"decr", true, true},
 	{"decrby", true, true},
 	{"del", true, true},
-	{"discard", false, false}, // dont support transactions
+	{"discard", false, true},
 	{"dump", true, true},
 	{"echo", true, true},
 	{"eval", false, true}, // can operate on several keys
 	{"evalsha", false, true},
-	{"exec", false, false},
+	{"exec", false, true},
 	{"exists", true, true},
 	{"expireat", true, true},
 	{"flushall", false, true},
@@ -232,8 +232,8 @@ var testDataAllRedisCommands = []struct {
 	{"monitor", false, false}, // system related operation - dangerous
 	{"move", false, false},    // moves between dbs, let's not support
 	{"mset", false, true},     // should operate on multiple keys
-	{"multi", false, false},   // transaction related
-	{"object", false, false},  // to inspect internals
+	{"multi", false, true},
+	{"object", false, false}, // to inspect internals
 	{"persist", true, true},
 	{"pexpire", true, true},
 	{"pexpireat", true, true},
@@ -290,8 +290,8 @@ var testDataAllRedisCommands = []struct {
 	{"ttl", true, true},
 	{"type", true, true},
 	{"unsubscribe", false, false},
-	{"unwatch", false, false}, // transaction related
-	{"watch", false, false},   // transaction related
+	{"unwatch", false, true},
+	{"watch", false, true},
 	{"zadd", true, true},
 	{"zcard", true, true},
 	{"zcount", true, true},

--- a/protocol/read_writer.go
+++ b/protocol/read_writer.go
@@ -30,7 +30,7 @@ import (
 	"time"
 )
 
-//A ReadWriter for a NetConnection's read/writer, that allows for sane & reliable timeouts applied to all of its operations
+// A ReadWriter for a NetConnection's read/writer, that allows for sane & reliable timeouts applied to all of its operations
 type TimedNetReadWriter struct {
 	//The underlying connection used by our remote (redis) connection
 	NetConnection net.Conn
@@ -40,7 +40,7 @@ type TimedNetReadWriter struct {
 	WriteTimeout time.Duration
 }
 
-//Wraps the net.connection's write function with a WriteDeadline
+// Wraps the net.connection's write function with a WriteDeadline
 func (myReadWriter *TimedNetReadWriter) Write(line []byte) (n int, err error) {
 	if myReadWriter.WriteTimeout > 0 {
 		myReadWriter.NetConnection.SetWriteDeadline(time.Now().Add(myReadWriter.WriteTimeout))
@@ -50,7 +50,7 @@ func (myReadWriter *TimedNetReadWriter) Write(line []byte) (n int, err error) {
 	return
 }
 
-//Wraps the net.connection's read function with a ReadDeadline
+// Wraps the net.connection's read function with a ReadDeadline
 func (myReadWriter *TimedNetReadWriter) Read(line []byte) (n int, err error) {
 	if myReadWriter.ReadTimeout > 0 {
 		myReadWriter.NetConnection.SetReadDeadline(time.Now().Add(myReadWriter.ReadTimeout))
@@ -60,7 +60,7 @@ func (myReadWriter *TimedNetReadWriter) Read(line []byte) (n int, err error) {
 	return
 }
 
-//Initializes a TimedNetReadWriter, with the given timeouts
+// Initializes a TimedNetReadWriter, with the given timeouts
 func NewTimedNetReadWriter(connection net.Conn, readTimeout, writeTimeout time.Duration) (newReadWriter *TimedNetReadWriter) {
 	newReadWriter = &TimedNetReadWriter{connection, readTimeout, writeTimeout}
 	return

--- a/protocol/scan.go
+++ b/protocol/scan.go
@@ -31,7 +31,7 @@ import (
 
 func ScanResp(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	//	if len(data) > 0 {
-//	//		Debug("Scanning %q", data)
+	//		Debug("Scanning %q", data)
 	//	}
 
 	if atEOF && len(data) == 0 {
@@ -203,7 +203,7 @@ func ScanArray(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		return 0, nil, err
 	} else if advance == 0 || token == nil || len(token) < 3 {
 		if len(token) < 3 && len(token) > 0 {
-//			Debug("Hm. %q", token)
+			// Debug("Hm. %q", token)
 		}
 		// Asking for more data
 		return 0, nil, nil
@@ -238,4 +238,3 @@ func ScanArray(data []byte, atEOF bool) (advance int, token []byte, err error) {
 
 	return s, data[:s], nil
 }
-

--- a/protocol/scanner.go
+++ b/protocol/scanner.go
@@ -34,8 +34,8 @@ import (
 type RespScanner struct {
 	r     io.Reader
 	token []byte
-	tmp [2048]byte // temp read buffer
-	b *bytes.Buffer
+	tmp   [2048]byte // temp read buffer
+	b     *bytes.Buffer
 	err   error
 
 	empties int

--- a/server.go
+++ b/server.go
@@ -26,21 +26,21 @@
 package rmux
 
 import (
+	"bytes"
 	"fmt"
-	"github.com/salesforce/rmux/connection"
-	"github.com/salesforce/rmux/graphite"
-	. "github.com/salesforce/rmux/log"
-	"github.com/salesforce/rmux/protocol"
 	"io"
 	"net"
 	"os"
 	"os/signal"
+	"rmux/connection"
+	"rmux/graphite"
+	"rmux/log"
+	"rmux/protocol"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
-	"bytes"
 )
 
 var (
@@ -52,9 +52,9 @@ var (
 
 var version string = "dev"
 
-//The main RedisMultiplexer
-//Listens on a specified socket or port, and assigns out queries to any number of connection pools
-//If more than one connection pool is given multi-key operations are blocked
+// The main RedisMultiplexer
+// Listens on a specified socket or port, and assigns out queries to any number of connection pools
+// If more than one connection pool is given multi-key operations are blocked
 type RedisMultiplexer struct {
 	HashRing *connection.HashRing
 	//hashmap of [connection endpoint] -> connectionPools
@@ -93,7 +93,7 @@ type RedisMultiplexer struct {
 	Failover bool
 }
 
-//Sub-task that handles the cleanup when a server goes down
+// Sub-task that handles the cleanup when a server goes down
 func (this *RedisMultiplexer) initializeCleanup() {
 	//Make a single-item channel for sigterm requests
 	c := make(chan os.Signal, 1)
@@ -110,8 +110,8 @@ func (this *RedisMultiplexer) initializeCleanup() {
 	os.Exit(0)
 }
 
-//Initializes a new redis multiplexer, listening on the given protocol/endpoint, with a set connectionPool size
-//ex: "unix", "/tmp/myAwesomeSocket", 50
+// Initializes a new redis multiplexer, listening on the given protocol/endpoint, with a set connectionPool size
+// ex: "unix", "/tmp/myAwesomeSocket", 50
 func NewRedisMultiplexer(listenProtocol, listenEndpoint string, poolSize int) (newRedisMultiplexer *RedisMultiplexer, err error) {
 	newRedisMultiplexer = &RedisMultiplexer{}
 	newRedisMultiplexer.Listener, err = net.Listen(listenProtocol, listenEndpoint)
@@ -128,11 +128,11 @@ func NewRedisMultiplexer(listenProtocol, listenEndpoint string, poolSize int) (n
 	newRedisMultiplexer.ClientReadTimeout = connection.EXTERN_READ_TIMEOUT
 	newRedisMultiplexer.ClientWriteTimeout = connection.EXTERN_WRITE_TIMEOUT
 	newRedisMultiplexer.infoMutex = sync.RWMutex{}
-//	Debug("Redis Multiplexer Initialized")
+	//	Debug("Redis Multiplexer Initialized")
 	return
 }
 
-//Adds a connection to the redis multiplexer, for the given protocol and endpoint
+// Adds a connection to the redis multiplexer, for the given protocol and endpoint
 func (this *RedisMultiplexer) AddConnection(remoteProtocol, remoteEndpoint string) {
 	connectionCluster := connection.NewConnectionPool(remoteProtocol, remoteEndpoint, this.PoolSize,
 		this.EndpointConnectTimeout, this.EndpointReadTimeout, this.EndpointWriteTimeout)
@@ -144,7 +144,7 @@ func (this *RedisMultiplexer) AddConnection(remoteProtocol, remoteEndpoint strin
 	}
 }
 
-//Counts the number of active endpoints on the server
+// Counts the number of active endpoints on the server
 func (this *RedisMultiplexer) countActiveConnections() (activeConnections int) {
 	activeConnections = 0
 	for _, connectionPool := range this.ConnectionCluster {
@@ -155,20 +155,20 @@ func (this *RedisMultiplexer) countActiveConnections() (activeConnections int) {
 	return
 }
 
-//Checks the status of all connections, and calculates how many of them are currently up
+// Checks the status of all connections, and calculates how many of them are currently up
 func (this *RedisMultiplexer) maintainConnectionStates() {
 	var m runtime.MemStats
 	for this.active {
 		this.activeConnectionCount = this.countActiveConnections()
-//		// Debug("We have %d connections", this.connectionCount)
+		//		// Debug("We have %d connections", this.connectionCount)
 		runtime.ReadMemStats(&m)
-//		// Debug("Memory profile: InUse(%d) Idle (%d) Released(%d)", m.HeapInuse, m.HeapIdle, m.HeapReleased)
+		//		// Debug("Memory profile: InUse(%d) Idle (%d) Released(%d)", m.HeapInuse, m.HeapIdle, m.HeapReleased)
 		this.generateMultiplexInfo()
 		time.Sleep(100 * time.Millisecond)
 	}
 }
 
-//Generates the Info response for a multiplexed server
+// Generates the Info response for a multiplexed server
 func (this *RedisMultiplexer) generateMultiplexInfo() {
 	tmpSlice := fmt.Sprintf("rmux_version: %s\r\ngo_version: %s\r\nprocess_id: %d\r\nconnected_clients: %d\r\nactive_endpoints: %d\r\ntotal_endpoints: %d\r\nrole: master\r\n", version, runtime.Version(), os.Getpid(), this.connectionCount, this.activeConnectionCount, len(this.ConnectionCluster))
 	this.infoMutex.Lock()
@@ -176,7 +176,7 @@ func (this *RedisMultiplexer) generateMultiplexInfo() {
 	this.infoMutex.Unlock()
 }
 
-//Called when a rmux server is ready to begin accepting connections
+// Called when a rmux server is ready to begin accepting connections
 func (this *RedisMultiplexer) Start() (err error) {
 	this.HashRing, err = connection.NewHashRing(this.ConnectionCluster, this.Failover)
 	if err != nil {
@@ -192,10 +192,10 @@ func (this *RedisMultiplexer) Start() (err error) {
 	for this.active {
 		fd, err := this.Listener.Accept()
 		if err != nil {
-//			Debug("Start: Error received from listener.Accept: %s", err.Error())
+			//			Debug("Start: Error received from listener.Accept: %s", err.Error())
 			continue
 		}
-//		Debug("Accepted connection.")
+		//		Debug("Accepted connection.")
 		graphite.Increment("accepted")
 
 		go this.initializeClient(fd)
@@ -204,7 +204,7 @@ func (this *RedisMultiplexer) Start() (err error) {
 	return
 }
 
-//Initializes a client's connection to our server.  Sets up our disconnect hooks and then passes the client off for request handling
+// Initializes a client's connection to our server.  Sets up our disconnect hooks and then passes the client off for request handling
 func (this *RedisMultiplexer) initializeClient(localConnection net.Conn) {
 	defer func() {
 		atomic.AddInt32(&this.connectionCount, -1)
@@ -216,21 +216,21 @@ func (this *RedisMultiplexer) initializeClient(localConnection net.Conn) {
 
 	defer func() {
 		if r := recover(); r != nil {
-//			DebugPanic(r)
+			//			DebugPanic(r)
 			if val, ok := r.(string); ok {
 				// If we paniced, push that to the client before closing the connection
 				protocol.WriteError([]byte(val), myClient.Writer, true)
 			}
 		}
 
-//		Debug("Closing client connection.")
+		//		Debug("Closing client connection.")
 		myClient.Connection.Close()
 	}()
 
 	this.HandleClientRequests(myClient)
 }
 
-//Sends the pre-generated Info response for a multiplexed server
+// Sends the pre-generated Info response for a multiplexed server
 func (this *RedisMultiplexer) sendMultiplexInfo(myClient *Client) (err error) {
 	this.infoMutex.RLock()
 	err = protocol.WriteLine(this.infoResponse, myClient.Writer, true)
@@ -247,15 +247,15 @@ func (this *RedisMultiplexer) GraphiteCheckin() {
 	}
 }
 
-//Handles requests for a client.
-//Inspects all incoming commands, to find if they are key-driven or not.
-//If they are, finds the appropriate connection pool, and passes the request off to it.
+// Handles requests for a client.
+// Inspects all incoming commands, to find if they are key-driven or not.
+// If they are, finds the appropriate connection pool, and passes the request off to it.
 func (this *RedisMultiplexer) HandleClientRequests(client *Client) {
 	// Create background i/o thread
 	go client.ReadLoop(this)
 
 	defer func() {
-//		Debug("Client command handling loop closing")
+		//		Debug("Client command handling loop closing")
 		// If the multiplexer goes down, deactivate this client.
 		client.Active = false
 	}()
@@ -306,7 +306,7 @@ func (this *RedisMultiplexer) HandleCommand(client *Client, command protocol.Com
 		return
 	}
 
-//	Debug("Writing out %q", command)
+	//	Debug("Writing out %q", command)
 	immediateResponse, err := client.ParseCommand(command)
 
 	if immediateResponse != nil {
@@ -317,7 +317,7 @@ func (this *RedisMultiplexer) HandleCommand(client *Client, command protocol.Com
 
 		err = client.WriteLine(immediateResponse)
 		if err != nil {
-//			Debug("Error received when writing an immediate response: %s", err)
+			//			Debug("Error received when writing an immediate response: %s", err)
 		}
 
 		return
@@ -354,7 +354,7 @@ func (this *RedisMultiplexer) HandleError(client *Client, err error) {
 		return
 	} else if recErr, ok := err.(*protocol.RecoverableError); ok {
 		// Since we can recover, flush an error to the client
-		Error("Error from server: %s", recErr)
+		log.Error("Error from server: %s", recErr)
 		client.FlushError(recErr)
 		return
 	} else if err == io.EOF {


### PR DESCRIPTION
Add support for `watch`, `unwatch`, `multi`, `exec` and `discard` Redis commands in non-multiplexing mode. When a transaction is detected the pool connection gets reserved for the specific client and only handed back when the client finishes the transaction.

To ensure that a client can't hog a connection forever a timeout can be specified after which the connection will be removed from the client (pool connection will get reconnected to ensure a clean state and the client disconnected with an error message).

This implementation works well if there are only short running transactions. Ideally, no `watch` is used and the whole transaction is sent within one pipeline (e.g. `redis-py` does this in its default pipeline mode) then no connection needs to be reserved over multiple cycles. `watch` still works properly but one needs to make sure to finish a transaction as soon as possible to not block the connection too long and exhaust the pool.

This PR is based on the updated Go structure from our PR https://github.com/salesforce/rmux/pull/26. In case you are not interested in the new Go structure we could rebase this PR on your master.